### PR TITLE
fixing crash when escaped double quotes enclose the url

### DIFF
--- a/image_scraper.gemspec
+++ b/image_scraper.gemspec
@@ -4,8 +4,8 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = "image_scraper"
-  s.version = "0.1.8.1"
+  s.name = "rcarvalho-image_scraper"
+  s.version = "0.1.8.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["John McAliley"]

--- a/image_scraper.gemspec
+++ b/image_scraper.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "rcarvalho-image_scraper"
-  s.version = "0.1.8.2"
+  s.version = "0.1.8.3"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["John McAliley"]

--- a/image_scraper.gemspec
+++ b/image_scraper.gemspec
@@ -5,11 +5,11 @@
 
 Gem::Specification.new do |s|
   s.name = "image_scraper"
-  s.version = "0.1.8"
+  s.version = "0.1.8.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["John McAliley"]
-  s.date = "2013-01-17"
+  s.date = "2013-10-23"
   s.description = "Simple utility to pull image urls from web page"
   s.email = "john.mcaliley@gmail.com"
   s.extra_rdoc_files = [

--- a/image_scraper.gemspec
+++ b/image_scraper.gemspec
@@ -5,11 +5,11 @@
 
 Gem::Specification.new do |s|
   s.name = "rcarvalho-image_scraper"
-  s.version = "0.1.8.3"
+  s.version = "0.1.8.8"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["John McAliley"]
-  s.date = "2013-10-23"
+  s.date = "2013-10-24"
   s.description = "Simple utility to pull image urls from web page"
   s.email = "john.mcaliley@gmail.com"
   s.extra_rdoc_files = [

--- a/lib/image_scraper/client.rb
+++ b/lib/image_scraper/client.rb
@@ -10,7 +10,7 @@ module ImageScraper
       @include_css_images = options[:include_css_images]
       @include_css_data_images = options[:include_css_data_images]
       html = open(@url).read rescue nil
-      @doc = html ? Nokogiri::HTML(html) : nil
+      @doc = html ? Nokogiri::HTML(html, nil, 'UTF-8') : nil
     end
 
     def image_urls

--- a/lib/image_scraper/client.rb
+++ b/lib/image_scraper/client.rb
@@ -37,7 +37,7 @@ module ImageScraper
       stylesheets.each do |stylesheet|
         file = open(stylesheet) rescue next
         css = file.string rescue IO.read(file) rescue next
-
+        css = css.unpack("C*").pack("U*")
         images += css.scan(/url\((.*?)\)/).collect do |image_url|
           image_url = URI.escape ImageScraper::Util.cleanup_url(image_url[0])
           image_url = image_url.gsub(/([{}|\^\[\]\@`])/) {|s| CGI.escape(s)} # escape characters that URI.escape doesn't get
@@ -48,14 +48,14 @@ module ImageScraper
           end
         end
       end
-      images
+      images.compact
     end
 
     def stylesheets
       return [] if doc.blank?
       doc.xpath('//link[@rel="stylesheet"]').collect do |stylesheet|
-        ImageScraper::Util.absolute_url url, URI.escape(ImageScraper::Util.cleanup_url(stylesheet['href']))
-      end
+        ImageScraper::Util.absolute_url url, URI.escape(ImageScraper::Util.cleanup_url(stylesheet['href'])) rescue nil
+      end.compact
     end
   end
 end

--- a/lib/image_scraper/client.rb
+++ b/lib/image_scraper/client.rb
@@ -39,12 +39,11 @@ module ImageScraper
         css = file.string rescue IO.read(file) rescue next
 
         images += css.scan(/url\((.*?)\)/).collect do |image_url|
-          image_url = URI.escape image_url[0]
+          image_url = URI.escape ImageScraper::Util.cleanup_url(image_url[0])
           image_url = image_url.gsub(/([{}|\^\[\]\@`])/) {|s| CGI.escape(s)} # escape characters that URI.escape doesn't get
           if image_url.include?("data:image") and @include_css_data_images
             image_url
           else
-            image_url = ImageScraper::Util.strip_quotes(image_url)
             @convert_to_absolute_url ? ImageScraper::Util.absolute_url(stylesheet, image_url) : image_url
           end
         end
@@ -55,7 +54,7 @@ module ImageScraper
     def stylesheets
       return [] if doc.blank?
       doc.xpath('//link[@rel="stylesheet"]').collect do |stylesheet|
-        ImageScraper::Util.absolute_url url, URI.escape(stylesheet['href'])
+        ImageScraper::Util.absolute_url url, URI.escape(ImageScraper::Util.cleanup_url(stylesheet['href']))
       end
     end
   end

--- a/lib/image_scraper/util.rb
+++ b/lib/image_scraper/util.rb
@@ -26,7 +26,7 @@ module ImageScraper
     end
     
     def self.strip_quotes(image_url)
-      image_url.gsub("'","").gsub('"','')
+      image_url.sub(/^%22/,'').sub(/%22$/,'').gsub("'","").gsub('"','')
     end
   end
 end

--- a/lib/image_scraper/util.rb
+++ b/lib/image_scraper/util.rb
@@ -26,7 +26,7 @@ module ImageScraper
     end
     
     def self.strip_quotes(image_url)
-      image_url.sub(/^%22/,'').sub(/%22$/,'').gsub("'","").gsub('"','')
+      image_url.sub(/^%22/,'').sub(/%22$/,'').sub(/^%20/,'').sub(/%20$/,'').gsub("'","").gsub('"','')
     end
   end
 end

--- a/lib/image_scraper/util.rb
+++ b/lib/image_scraper/util.rb
@@ -26,7 +26,15 @@ module ImageScraper
     end
     
     def self.strip_quotes(image_url)
-      image_url.sub(/^%22/,'').sub(/%22$/,'').sub(/^%20/,'').sub(/%20$/,'').gsub("'","").gsub('"','')
+      image_url.gsub("'","").gsub('"','')
+    end
+
+    def self.chomp(image_url)
+      image_url.gsub(/\s/,'')
+    end
+
+    def self.cleanup_url(image_url)
+      ImageScraper::Util.chomp(ImageScraper::Util.strip_quotes(image_url))
     end
   end
 end

--- a/lib/image_scraper/util.rb
+++ b/lib/image_scraper/util.rb
@@ -12,7 +12,7 @@ module ImageScraper
       #          'http://example.com/style.css
       #          but should get:
       #          'http://example.com/about/style.css
-      URI.parse(url).merge(URI.parse asset.to_s).to_s
+      URI.parse(url).merge(URI.parse asset.to_s).to_s rescue nil
     end
     
     def self.domain(url)
@@ -24,6 +24,10 @@ module ImageScraper
       uri = URI.parse(url)
       uri.path
     end
+
+    def self.strip_backslashes(image_url)
+      image_url.gsub("\\",'')
+    end
     
     def self.strip_quotes(image_url)
       image_url.gsub("'","").gsub('"','')
@@ -34,7 +38,9 @@ module ImageScraper
     end
 
     def self.cleanup_url(image_url)
-      ImageScraper::Util.chomp(ImageScraper::Util.strip_quotes(image_url))
+      ImageScraper::Util.chomp(
+        ImageScraper::Util.strip_quotes(
+          ImageScraper::Util.strip_backslashes(image_url || '')))
     end
   end
 end

--- a/test/test_image_scraper.rb
+++ b/test/test_image_scraper.rb
@@ -6,6 +6,10 @@ require 'helper'
 # Consider using https://raw.github.com/charlotte-ruby/image_scraper urls
 
 class TestImageScraper < Test::Unit::TestCase
+  should "parse urls even with escaped (%22) double quotes in them" do
+    scraper = ImageScraper::Client.new "http://newscorp.com/careers/"
+  end
+
   should "return list of all image urls on a web page with absolute paths" do
     images = ["http://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/SIPI_Jelly_Beans_4.1.07.tiff/lossy-page1-220px-SIPI_Jelly_Beans_4.1.07.tiff.jpg",
               "http://bits.wikimedia.org/static-1.21wmf9/skins/common/images/magnify-clip.png",


### PR DESCRIPTION
This fixes the issue of an escaped quote being at the beginning or end of the url, which throws a URI parse error.
