### PR TITLE
deprecate travis in favor of github action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,8 +22,6 @@ jobs:
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-script: bundle exec rake
-language: ruby
-


### PR DESCRIPTION
Just adding this because I think it's neat. There's really no difference on what's being tested, just using github actions instead
